### PR TITLE
Implement profile tabs with reviews and contributions data

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,8 @@
 module.exports = function (api) {
   api.cache(true);
 
+  const isTest = process.env.NODE_ENV === "test";
+
   return {
     presets: [
       [
@@ -12,15 +14,21 @@ module.exports = function (api) {
     ],
     plugins: [
       // expo-router/babel is now included in babel-preset-expo in SDK 50
-      [
-        "module:react-native-dotenv",
-        {
-          moduleName: "@env",
-          path: ".env.local",
-          safe: true,
-          allowUndefined: false,
-        },
-      ],
+      // Skip react-native-dotenv in test environment — Jest's moduleNameMapper
+      // handles @env via __mocks__/env.js, and the plugin crashes without .env.local
+      ...(isTest
+        ? []
+        : [
+            [
+              "module:react-native-dotenv",
+              {
+                moduleName: "@env",
+                path: ".env.local",
+                safe: true,
+                allowUndefined: false,
+              },
+            ],
+          ]),
     ],
   };
 };

--- a/src/__tests__/services/contribution.test.ts
+++ b/src/__tests__/services/contribution.test.ts
@@ -79,6 +79,7 @@ import {
   contributionService,
   validateToiletSubmission,
   VALIDATION_LIMITS,
+  MAX_RECENT_SUBMISSIONS,
 } from "../../services/contributionService";
 import {
   checkSession,
@@ -310,6 +311,68 @@ describe("Contribution Service", () => {
         contributionService.cleanupOldSubmissions();
 
         expect(contributionService.recentSubmissions.has(hash)).toBe(true);
+      });
+    });
+
+    describe("recentSubmissions size cap", () => {
+      it("should evict oldest entry when exceeding MAX_RECENT_SUBMISSIONS", () => {
+        // Fill the Map to MAX + 1 entries
+        const now = Date.now();
+        for (let i = 0; i <= MAX_RECENT_SUBMISSIONS; i++) {
+          contributionService.recentSubmissions.set(`hash-${i}`, {
+            timestamp: now + i, // each newer than the last
+            id: `sub-${i}`,
+          });
+        }
+
+        // Record one more submission to trigger the cap
+        contributionService.recordSubmission(
+          { name: "Cap Test", location: { latitude: 0, longitude: 0 } },
+          "cap-submission",
+        );
+
+        // Should not exceed the max
+        expect(contributionService.recentSubmissions.size).toBeLessThanOrEqual(
+          MAX_RECENT_SUBMISSIONS,
+        );
+      });
+
+      it("should evict the oldest entry, not the newest", () => {
+        const now = Date.now();
+
+        // Add MAX entries, with hash-0 being the oldest
+        for (let i = 0; i < MAX_RECENT_SUBMISSIONS; i++) {
+          contributionService.recentSubmissions.set(`hash-${i}`, {
+            timestamp: now + i,
+            id: `sub-${i}`,
+          });
+        }
+
+        // Add one more to trigger eviction
+        contributionService.recordSubmission(
+          { name: "Trigger Evict", location: { latitude: 1, longitude: 1 } },
+          "newest-submission",
+        );
+
+        // The oldest entry (hash-0) should have been evicted
+        expect(contributionService.recentSubmissions.has("hash-0")).toBe(false);
+        // The second-oldest should still be there
+        expect(contributionService.recentSubmissions.has("hash-1")).toBe(true);
+        // The newly added entry should exist
+        const newHash = contributionService.generateSubmissionHash({
+          name: "Trigger Evict",
+          location: { latitude: 1, longitude: 1 },
+        });
+        expect(contributionService.recentSubmissions.has(newHash)).toBe(true);
+      });
+
+      it("should not evict when under the cap", () => {
+        contributionService.recordSubmission(
+          { name: "Single Entry", location: { latitude: 0, longitude: 0 } },
+          "only-one",
+        );
+
+        expect(contributionService.recentSubmissions.size).toBe(1);
       });
     });
   });

--- a/src/__tests__/services/supabase-auth.test.ts
+++ b/src/__tests__/services/supabase-auth.test.ts
@@ -104,9 +104,15 @@ jest.mock("@env", () => ({
 }));
 
 // Import after mocks are set up
-import { supabaseService, refreshSession, checkSession, getSupabaseClient } from "../../services/supabase";
 import type { AuthResponse, Session } from "@supabase/supabase-js";
 import { Platform } from "react-native";
+
+import {
+  supabaseService,
+  refreshSession,
+  checkSession,
+  getSupabaseClient,
+} from "../../services/supabase";
 
 describe("Authentication Service", () => {
   // Get the mocked auth object from the singleton client
@@ -232,7 +238,7 @@ describe("Authentication Service", () => {
         supabaseService.auth.signUp({
           email: "test@example.com",
           password: "SecurePass123!",
-        })
+        }),
       ).rejects.toThrow("Network request failed");
 
       const { captureException } = require("../../services/sentry");
@@ -267,7 +273,9 @@ describe("Authentication Service", () => {
         error: null,
       };
 
-      mockSupabaseAuth.signInWithPassword.mockResolvedValueOnce(mockAuthResponse);
+      mockSupabaseAuth.signInWithPassword.mockResolvedValueOnce(
+        mockAuthResponse,
+      );
 
       const result = await supabaseService.auth.signIn({
         email: "test@example.com",
@@ -314,7 +322,7 @@ describe("Authentication Service", () => {
         supabaseService.auth.signIn({
           email: "test@example.com",
           password: "SecurePass123!",
-        })
+        }),
       ).rejects.toThrow("Network request failed");
 
       const { captureException } = require("../../services/sentry");
@@ -371,7 +379,9 @@ describe("Authentication Service", () => {
       const networkError = new Error("Network request failed");
       mockSupabaseAuth.signOut.mockRejectedValueOnce(networkError);
 
-      await expect(supabaseService.auth.signOut()).rejects.toThrow("Network request failed");
+      await expect(supabaseService.auth.signOut()).rejects.toThrow(
+        "Network request failed",
+      );
 
       const { captureException } = require("../../services/sentry");
       expect(captureException).toHaveBeenCalledWith(networkError, {
@@ -413,7 +423,8 @@ describe("Authentication Service", () => {
         error: null,
       });
 
-      const result = await supabaseService.auth.updatePassword("NewSecurePass123!");
+      const result =
+        await supabaseService.auth.updatePassword("NewSecurePass123!");
 
       expect(result.error).toBeNull();
       expect(result.data.user).toEqual(mockUser);
@@ -429,7 +440,8 @@ describe("Authentication Service", () => {
         error: mockError,
       });
 
-      const result = await supabaseService.auth.updatePassword("NewSecurePass123!");
+      const result =
+        await supabaseService.auth.updatePassword("NewSecurePass123!");
 
       expect(result.error).toEqual(mockError);
       expect(result.data.user).toBeNull();
@@ -496,7 +508,7 @@ describe("Authentication Service", () => {
       mockSupabaseAuth.getSession.mockRejectedValueOnce(networkError);
 
       await expect(supabaseService.auth.getSession()).rejects.toThrow(
-        "Network request failed"
+        "Network request failed",
       );
     });
   });
@@ -526,7 +538,10 @@ describe("Authentication Service", () => {
     });
 
     it("should retry on failure and succeed on second attempt", async () => {
-      const mockError = { message: "Temporary failure", code: "temporary_error" };
+      const mockError = {
+        message: "Temporary failure",
+        code: "temporary_error",
+      };
       const mockSession = {
         access_token: "new-mock-token",
         refresh_token: "new-mock-refresh",
@@ -593,9 +608,9 @@ describe("Authentication Service", () => {
                   data: { session: mockSession, user: null },
                   error: null,
                 }),
-              100
-            )
-          )
+              100,
+            ),
+          ),
       );
 
       // Start two refresh operations concurrently
@@ -902,6 +917,107 @@ describe("Authentication Service", () => {
       expect(result.valid).toBe(false);
       expect(result.session).toBeNull();
       expect(result.detailedStatus).toBe("no_session");
+    });
+  });
+
+  describe("Timestamp normalization edge cases", () => {
+    it("should handle expires_at as integer Unix seconds (standard Supabase format)", async () => {
+      // Supabase SDK always sets: Math.round(Date.now() / 1000) + expires_in
+      const unixSeconds = Math.round(Date.now() / 1000) + 7200; // 2 hours
+      const mockSession = {
+        access_token: "mock-token",
+        refresh_token: "mock-refresh",
+        expires_at: unixSeconds,
+        user: { id: "user-123" },
+      } as Session;
+
+      mockSupabaseAuth.getSession.mockResolvedValueOnce({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      const result = await checkSession();
+
+      expect(result.valid).toBe(true);
+      expect(result.expiresIn).toBeGreaterThan(7100);
+      expect(result.expiresIn).toBeLessThan(7300);
+    });
+
+    it("should handle expires_at of 0 as invalid", async () => {
+      const mockSession = {
+        access_token: "mock-token",
+        refresh_token: "mock-refresh",
+        expires_at: 0 as any,
+        user: { id: "user-123" },
+      } as Session;
+
+      mockSupabaseAuth.getSession.mockResolvedValueOnce({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      const result = await checkSession();
+
+      expect(result.valid).toBe(false);
+      expect(result.needsForceRefresh).toBe(true);
+    });
+
+    it("should handle expires_at as negative number as invalid", async () => {
+      const mockSession = {
+        access_token: "mock-token",
+        refresh_token: "mock-refresh",
+        expires_at: -100 as any,
+        user: { id: "user-123" },
+      } as Session;
+
+      mockSupabaseAuth.getSession.mockResolvedValueOnce({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      const result = await checkSession();
+
+      expect(result.valid).toBe(false);
+      expect(result.needsForceRefresh).toBe(true);
+    });
+
+    it("should handle expires_at as numeric string (Unix seconds)", async () => {
+      const unixSeconds = Math.round(Date.now() / 1000) + 1800;
+      const mockSession = {
+        access_token: "mock-token",
+        refresh_token: "mock-refresh",
+        expires_at: String(unixSeconds) as any,
+        user: { id: "user-123" },
+      } as Session;
+
+      mockSupabaseAuth.getSession.mockResolvedValueOnce({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      const result = await checkSession();
+
+      expect(result.valid).toBe(true);
+      expect(result.expiresIn).toBeGreaterThan(1700);
+      expect(result.expiresIn).toBeLessThan(1900);
+    });
+
+    it("should handle undefined expires_at gracefully", async () => {
+      const mockSession = {
+        access_token: "mock-token",
+        refresh_token: "mock-refresh",
+        user: { id: "user-123" },
+      } as Session;
+
+      mockSupabaseAuth.getSession.mockResolvedValueOnce({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      const result = await checkSession();
+
+      // expires_at is undefined → normalizeTimestamp returns null → treated as expired
+      expect(result.valid).toBe(false);
     });
   });
 

--- a/src/app/profile/index.tsx
+++ b/src/app/profile/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useRouter } from "expo-router";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { StyleSheet, View, ScrollView, Alert } from "react-native";
 import { Divider, Text, Card, Button } from "react-native-paper";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -17,17 +17,84 @@ import { ErrorState } from "../../components/shared/ErrorState";
 import { LoadingState } from "../../components/shared/LoadingState";
 import { colors } from "../../foundations/colors";
 import { useAuth } from "../../providers/AuthProvider";
-import type {
-  UserReview,
-  UserContribution,
-  UserFavorite,
-} from "../../types/profile-content";
+import { contributionService } from "../../services/contributionService";
+import { supabaseService } from "../../services/supabase";
+import type { SubmissionPreview } from "../../types/contribution";
+import type { UserReview, UserFavorite } from "../../types/profile-content";
 import { debug } from "../../utils/debug";
 
 export default function ProfileScreen() {
   const router = useRouter();
   const { user, profile, isLoading, isAuthenticated, signOut } = useAuth();
   const [activeTab, setActiveTab] = useState(0);
+
+  // Tab data state
+  const [reviews, setReviews] = useState<UserReview[] | null>(null);
+  const [reviewsLoading, setReviewsLoading] = useState(false);
+  const [contributions, setContributions] = useState<
+    SubmissionPreview[] | null
+  >(null);
+  const [contributionsLoading, setContributionsLoading] = useState(false);
+
+  // Fetch data when tab changes
+  useEffect(() => {
+    if (!user) return;
+
+    if (activeTab === 0 && reviews === null && !reviewsLoading) {
+      setReviewsLoading(true);
+      supabaseService.reviews
+        .getByUserId(user.id)
+        .then((data) => setReviews(data as UserReview[]))
+        .catch((err) => {
+          debug.error("Profile", "Failed to fetch reviews", err);
+          setReviews([]);
+        })
+        .finally(() => setReviewsLoading(false));
+    }
+
+    if (activeTab === 1 && contributions === null && !contributionsLoading) {
+      setContributionsLoading(true);
+      contributionService
+        .getMySubmissions()
+        .then((data) => setContributions(data))
+        .catch((err) => {
+          debug.error("Profile", "Failed to fetch contributions", err);
+          setContributions([]);
+        })
+        .finally(() => setContributionsLoading(false));
+    }
+  }, [
+    activeTab,
+    user,
+    reviews,
+    reviewsLoading,
+    contributions,
+    contributionsLoading,
+  ]);
+
+  // Pull-to-refresh handlers
+  const refreshReviews = useCallback(() => {
+    if (!user) return;
+    setReviewsLoading(true);
+    supabaseService.reviews
+      .getByUserId(user.id)
+      .then((data) => setReviews(data as UserReview[]))
+      .catch((err) => {
+        debug.error("Profile", "Failed to refresh reviews", err);
+      })
+      .finally(() => setReviewsLoading(false));
+  }, [user]);
+
+  const refreshContributions = useCallback(() => {
+    setContributionsLoading(true);
+    contributionService
+      .getMySubmissions()
+      .then((data) => setContributions(data))
+      .catch((err) => {
+        debug.error("Profile", "Failed to refresh contributions", err);
+      })
+      .finally(() => setContributionsLoading(false));
+  }, []);
 
   // Navigation callbacks
   const handleEditPress = useCallback(() => {
@@ -62,7 +129,7 @@ export default function ProfileScreen() {
             debug.error("Profile", "Logout failed with exception", error);
             Alert.alert(
               "Error",
-              "An unexpected error occurred. Please try again."
+              "An unexpected error occurred. Please try again.",
             );
           }
         },
@@ -169,38 +236,88 @@ export default function ProfileScreen() {
           {/* Tab content */}
           <View style={styles.tabContent}>
             {activeTab === 0 && (
-              <ContentList
-                data={null}
-                isLoading={false}
+              <ContentList<UserReview>
+                data={reviews}
+                isLoading={reviewsLoading}
                 emptyStateIcon="note-text-outline"
                 emptyStateTitle="No Reviews Yet"
                 emptyStateMessage="Your reviews will appear here"
-                keyExtractor={(item: UserReview) => item.id}
-                renderItem={({ item: _ }) => <View />} // Placeholder for future implementation
+                keyExtractor={(item) => item.id}
+                onRefresh={refreshReviews}
+                isRefreshing={reviewsLoading}
+                renderItem={({ item }) => (
+                  <Card style={styles.itemCard}>
+                    <Card.Content>
+                      <Text style={styles.itemTitle}>
+                        {item.toilet?.name || "Unknown Toilet"}
+                      </Text>
+                      <Text style={styles.itemSubtitle}>
+                        {"★".repeat(item.rating)}
+                        {"☆".repeat(5 - item.rating)}
+                      </Text>
+                      {item.comment ? (
+                        <Text style={styles.itemBody} numberOfLines={2}>
+                          {item.comment}
+                        </Text>
+                      ) : null}
+                      <Text style={styles.itemDate}>
+                        {new Date(item.created_at).toLocaleDateString()}
+                      </Text>
+                    </Card.Content>
+                  </Card>
+                )}
               />
             )}
 
             {activeTab === 1 && (
-              <ContentList
-                data={null}
-                isLoading={false}
+              <ContentList<SubmissionPreview>
+                data={contributions}
+                isLoading={contributionsLoading}
                 emptyStateIcon="source-commit"
                 emptyStateTitle="No Contributions Yet"
                 emptyStateMessage="Your contributions will appear here"
-                keyExtractor={(item: UserContribution) => item.id}
-                renderItem={({ item: _ }) => <View />} // Placeholder for future implementation
+                keyExtractor={(item) => item.id}
+                onRefresh={refreshContributions}
+                isRefreshing={contributionsLoading}
+                renderItem={({ item }) => (
+                  <Card style={styles.itemCard}>
+                    <Card.Content>
+                      <Text style={styles.itemTitle}>{item.toilet_name}</Text>
+                      <View style={styles.itemRow}>
+                        <Text style={styles.itemBadge}>
+                          {item.submission_type}
+                        </Text>
+                        <Text
+                          style={[
+                            styles.itemBadge,
+                            item.status === "approved"
+                              ? styles.badgeApproved
+                              : item.status === "rejected"
+                                ? styles.badgeRejected
+                                : styles.badgePending,
+                          ]}
+                        >
+                          {item.status}
+                        </Text>
+                      </View>
+                      <Text style={styles.itemDate}>
+                        {new Date(item.created_at).toLocaleDateString()}
+                      </Text>
+                    </Card.Content>
+                  </Card>
+                )}
               />
             )}
 
             {activeTab === 2 && (
-              <ContentList
+              <ContentList<UserFavorite>
                 data={null}
                 isLoading={false}
                 emptyStateIcon="heart-outline"
                 emptyStateTitle="No Favorites Yet"
                 emptyStateMessage="Your favorite toilets will appear here"
-                keyExtractor={(item: UserFavorite) => item.id}
-                renderItem={({ item: _ }) => <View />} // Placeholder for future implementation
+                keyExtractor={(item) => item.id}
+                renderItem={({ item: _ }) => <View />}
               />
             )}
           </View>
@@ -232,6 +349,18 @@ const styles = StyleSheet.create({
     color: colors.text.inverse,
     fontWeight: "bold",
   },
+  badgeApproved: {
+    backgroundColor: colors.status.success.background,
+    color: colors.status.success.foreground,
+  },
+  badgePending: {
+    backgroundColor: colors.status.warning.background,
+    color: colors.status.warning.foreground,
+  },
+  badgeRejected: {
+    backgroundColor: colors.status.error.background,
+    color: colors.status.error.foreground,
+  },
   container: {
     backgroundColor: colors.background.primary,
     flex: 1,
@@ -241,6 +370,43 @@ const styles = StyleSheet.create({
   },
   header: {
     marginTop: 8,
+  },
+  itemBadge: {
+    borderRadius: 4,
+    fontSize: 12,
+    fontWeight: "600",
+    marginRight: 8,
+    overflow: "hidden",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    textTransform: "capitalize",
+  },
+  itemBody: {
+    color: colors.text.secondary,
+    fontSize: 14,
+    marginTop: 4,
+  },
+  itemCard: {
+    marginBottom: 8,
+  },
+  itemDate: {
+    color: colors.text.secondary,
+    fontSize: 12,
+    marginTop: 4,
+  },
+  itemRow: {
+    flexDirection: "row",
+    marginTop: 4,
+  },
+  itemSubtitle: {
+    color: colors.text.secondary,
+    fontSize: 14,
+    marginTop: 2,
+  },
+  itemTitle: {
+    color: colors.text.primary,
+    fontSize: 16,
+    fontWeight: "600",
   },
   logoutButton: {
     borderColor: colors.status.error.foreground,

--- a/src/services/contributionService.ts
+++ b/src/services/contributionService.ts
@@ -98,6 +98,12 @@ export const VALIDATION_LIMITS = {
 } as const;
 
 /**
+ * Maximum number of recent submissions to track in memory.
+ * Each entry is ~200 bytes (hash key + timestamp + ID), so 100 entries ≈ 20KB.
+ */
+export const MAX_RECENT_SUBMISSIONS = 100;
+
+/**
  * Known amenity keys — any other keys are stripped.
  */
 const VALID_AMENITY_KEYS = new Set([
@@ -430,6 +436,21 @@ export const contributionService = {
 
     // Clean up old entries to prevent memory growth
     this.cleanupOldSubmissions();
+
+    // Hard cap: evict oldest entries if Map exceeds max size
+    while (this.recentSubmissions.size > MAX_RECENT_SUBMISSIONS) {
+      let oldest: { key: string; timestamp: number } | null = null;
+      for (const [key, value] of this.recentSubmissions.entries()) {
+        if (!oldest || value.timestamp < oldest.timestamp) {
+          oldest = { key, timestamp: value.timestamp };
+        }
+      }
+      if (oldest) {
+        this.recentSubmissions.delete(oldest.key);
+      } else {
+        break;
+      }
+    }
   },
 
   /**

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -1275,5 +1275,59 @@ export const supabaseService = {
         updatedAt: data.updated_at,
       } as Review;
     },
+
+    async getByUserId(userId: string) {
+      const { data, error } = await supabase
+        .from("reviews")
+        .select(
+          `
+          id,
+          toilet_id,
+          user_id,
+          rating,
+          comment,
+          photos,
+          created_at,
+          toilets (
+            name,
+            address
+          )
+        `,
+        )
+        .eq("user_id", userId)
+        .order("created_at", { ascending: false });
+
+      if (error) {
+        debug.error("Supabase", "Error fetching reviews by user ID", error);
+        throw error;
+      }
+
+      return (data || []).map(
+        (item: {
+          id: string;
+          toilet_id: string;
+          user_id: string;
+          rating: number;
+          comment: string | null;
+          photos: string[] | null;
+          created_at: string;
+          toilets: { name: string; address: string | null } | null;
+        }) => ({
+          id: item.id,
+          toilet_id: item.toilet_id,
+          user_id: item.user_id,
+          rating: item.rating,
+          comment: item.comment,
+          photos: item.photos || [],
+          created_at: item.created_at,
+          toilet: item.toilets
+            ? {
+                name: item.toilets.name,
+                address: item.toilets.address || undefined,
+              }
+            : undefined,
+        }),
+      );
+    },
   },
 };

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -161,11 +161,13 @@ class SupabaseClientSingleton {
   }
 
   /**
-   * Normalizes different timestamp formats to a JavaScript Date object
-   * Handles Unix timestamps (seconds), JavaScript timestamps (milliseconds),
-   * ISO strings, and other string date formats
+   * Converts a Supabase expires_at timestamp (Unix seconds) to a Date.
    *
-   * @param timestamp The timestamp to normalize
+   * The Supabase SDK always sets expires_at as Unix seconds:
+   *   expires_at: Math.round(Date.now() / 1000) + data.expires_in
+   * (see @supabase/auth-js GoTrueClient.ts)
+   *
+   * @param timestamp Unix timestamp in seconds, or null/undefined
    * @returns A JavaScript Date object or null if invalid
    */
   static normalizeTimestamp(
@@ -175,44 +177,23 @@ class SupabaseClientSingleton {
       return null;
     }
 
-    try {
-      // Handle numeric timestamps
-      if (typeof timestamp === "number") {
-        // Unix timestamps (seconds since epoch) typically have 10 digits
-        // JavaScript timestamps (milliseconds since epoch) have 13 digits
-        if (timestamp < 20000000000) {
-          // Heuristic for Unix timestamp (before year 2603)
-          return new Date(timestamp * 1000);
-        } else {
-          return new Date(timestamp);
-        }
-      }
+    const numeric =
+      typeof timestamp === "number" ? timestamp : Number(timestamp);
 
-      // Handle string timestamps
-      if (typeof timestamp === "string") {
-        // Try to parse as a number first
-        const numericValue = parseInt(timestamp, 10);
-        if (!isNaN(numericValue)) {
-          return this.normalizeTimestamp(numericValue);
-        }
-
-        // Try as ISO date string or other string formats
-        const dateObject = new Date(timestamp);
-        if (this.isValidDate(dateObject)) {
-          return dateObject;
-        }
-      }
-
-      // If we get here, the timestamp couldn't be parsed
-      debug.warn("Supabase", "Unknown timestamp format", { timestamp });
-      return null;
-    } catch (error) {
-      debug.error("Supabase", "Error normalizing timestamp", {
-        timestamp,
-        error,
-      });
+    if (isNaN(numeric) || numeric <= 0) {
+      debug.warn("Supabase", "Invalid session timestamp", { timestamp });
       return null;
     }
+
+    // Supabase expires_at is always Unix seconds. Convert to milliseconds.
+    const date = new Date(numeric * 1000);
+
+    if (!this.isValidDate(date)) {
+      debug.warn("Supabase", "Timestamp produced invalid date", { timestamp });
+      return null;
+    }
+
+    return date;
   }
 
   /**

--- a/src/stores/toilets.ts
+++ b/src/stores/toilets.ts
@@ -50,7 +50,7 @@ function calculateDistance(coords1: Coordinates, coords2: Coordinates): number {
 function shouldFetchNewData(
   lastFetchLocation: Coordinates | null,
   lastFetchTime: number | null,
-  currentLocation: Coordinates
+  currentLocation: Coordinates,
 ): boolean {
   // If we've never fetched before, we definitely need to fetch
   if (!lastFetchLocation || !lastFetchTime) {
@@ -82,7 +82,7 @@ function shouldFetchNewData(
       {
         distanceMoved,
         threshold: SIGNIFICANT_DISTANCE,
-      }
+      },
     );
     return true;
   }
@@ -97,7 +97,7 @@ function shouldFetchNewData(
       distanceMoved,
       cacheAgeSeconds: Math.round(cacheAge / 1000),
     },
-    CACHE_CHECK_LOG_THROTTLE
+    CACHE_CHECK_LOG_THROTTLE,
   );
   return false;
 }
@@ -112,7 +112,7 @@ interface ToiletState {
   fetchNearbyToilets: (
     latitude: number,
     longitude: number,
-    radius?: number
+    radius?: number,
   ) => Promise<void>;
   selectToilet: (toilet: Toilet | null) => void;
   clearError: () => void;
@@ -131,7 +131,7 @@ export const useToiletStore = create<ToiletState>()(
       fetchNearbyToilets: async (
         latitude: number,
         longitude: number,
-        radius = 5000
+        radius = 5000,
       ) => {
         try {
           const currentLocation = { latitude, longitude };
@@ -142,7 +142,7 @@ export const useToiletStore = create<ToiletState>()(
             !shouldFetchNewData(
               lastFetchLocation,
               lastFetchTime,
-              currentLocation
+              currentLocation,
             )
           ) {
             // Throttled logging for skipping fetch (30 second interval)
@@ -152,7 +152,7 @@ export const useToiletStore = create<ToiletState>()(
               `skip-fetch-${currentLocation.latitude.toFixed(4)}-${currentLocation.longitude.toFixed(4)}`,
               "Using cached toilets - skipping fetch",
               {},
-              SKIP_FETCH_LOG_THROTTLE
+              SKIP_FETCH_LOG_THROTTLE,
             );
             return;
           }
@@ -167,7 +167,7 @@ export const useToiletStore = create<ToiletState>()(
           const toilets = await supabaseService.toilets.getNearby(
             latitude,
             longitude,
-            radius
+            radius,
           );
 
           // Validate toilets data - TEMPORARILY USING LESS STRICT VALIDATION
@@ -192,7 +192,7 @@ export const useToiletStore = create<ToiletState>()(
                   hasCoords,
                   latitude: toilet?.location?.latitude,
                   longitude: toilet?.location?.longitude,
-                }
+                },
               );
             }
 
@@ -201,9 +201,8 @@ export const useToiletStore = create<ToiletState>()(
 
           // Log if any invalid toilets were found with details about what was invalid
           if (validToilets.length !== toilets.length) {
-            const invalidToilets = toilets.filter(
-              (t) => !validToilets.includes(t)
-            );
+            const validSet = new Set(validToilets);
+            const invalidToilets = toilets.filter((t) => !validSet.has(t));
             debug.warn(
               "ToiletStore",
               `Filtered out ${toilets.length - validToilets.length} invalid toilets`,
@@ -223,13 +222,13 @@ export const useToiletStore = create<ToiletState>()(
                     return "longitude out of range";
                   return "unknown reason";
                 }),
-              }
+              },
             );
           }
 
           debug.log(
             "ToiletStore",
-            `Fetched ${validToilets.length} valid toilets`
+            `Fetched ${validToilets.length} valid toilets`,
           );
           set({
             toilets: validToilets,
@@ -252,7 +251,7 @@ export const useToiletStore = create<ToiletState>()(
       selectToilet: (toilet) => {
         debug.log(
           "ToiletStore",
-          toilet ? `Selected toilet ${toilet.id}` : "Deselected toilet"
+          toilet ? `Selected toilet ${toilet.id}` : "Deselected toilet",
         );
         set({ selectedToilet: toilet });
       },
@@ -261,6 +260,6 @@ export const useToiletStore = create<ToiletState>()(
         set({ error: null });
       },
     }),
-    { name: "toilet-store" }
-  )
+    { name: "toilet-store" },
+  ),
 );

--- a/supabase/migrations/20250534_enable_rls_toilets_buildings_reviews_delete.sql
+++ b/supabase/migrations/20250534_enable_rls_toilets_buildings_reviews_delete.sql
@@ -1,0 +1,104 @@
+-- Migration: Enable RLS on toilets/buildings tables and add missing reviews DELETE policy
+-- Date: 2026-03-19
+-- Issue: N-RLS (Composite: 80) — toilets and buildings tables have no RLS;
+--        reviews table missing DELETE policy
+-- Context:
+--   - All toilet writes go through submit_toilet() RPC (SECURITY DEFINER)
+--   - All review writes go through create_review()/edit_review() RPCs (SECURITY DEFINER)
+--   - Buildings are reference-only (no direct writes from app)
+--   - SELECT must remain public for all three tables (map view, toilet detail, reviews)
+
+-- ===========================================================================
+-- 1. TOILETS TABLE — Enable RLS
+-- ===========================================================================
+
+ALTER TABLE public.toilets ENABLE ROW LEVEL SECURITY;
+
+-- Anyone (including anonymous/unauthenticated) can view toilets
+-- This is required for the map view and toilet detail screens
+DROP POLICY IF EXISTS "Anyone can view toilets" ON public.toilets;
+CREATE POLICY "Anyone can view toilets"
+  ON public.toilets
+  FOR SELECT
+  USING (true);
+
+-- Only authenticated users can insert toilets directly
+-- In practice, inserts go through submit_toilet() SECURITY DEFINER RPC,
+-- which bypasses RLS. This policy is a safety net for direct access.
+DROP POLICY IF EXISTS "Authenticated users can insert toilets" ON public.toilets;
+CREATE POLICY "Authenticated users can insert toilets"
+  ON public.toilets
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (true);
+
+-- Only the submitter or last editor can update a toilet directly
+-- In practice, updates go through submit_toilet() SECURITY DEFINER RPC
+-- and process_approved_submission() SECURITY DEFINER function.
+-- This policy is a safety net; it allows updates for the original submitter
+-- or any authenticated user if submitted_by is null (legacy data).
+DROP POLICY IF EXISTS "Submitter can update own toilets" ON public.toilets;
+CREATE POLICY "Submitter can update own toilets"
+  ON public.toilets
+  FOR UPDATE
+  TO authenticated
+  USING (
+    submitted_by IS NULL
+    OR auth.uid()::text = submitted_by::text
+  );
+
+-- No one can delete toilets directly via the API
+-- Toilet deletion should only happen through admin functions
+DROP POLICY IF EXISTS "No direct toilet deletion" ON public.toilets;
+CREATE POLICY "No direct toilet deletion"
+  ON public.toilets
+  FOR DELETE
+  USING (false);
+
+-- ===========================================================================
+-- 2. BUILDINGS TABLE — Enable RLS
+-- ===========================================================================
+
+ALTER TABLE public.buildings ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can view buildings (needed for map and toilet detail)
+DROP POLICY IF EXISTS "Anyone can view buildings" ON public.buildings;
+CREATE POLICY "Anyone can view buildings"
+  ON public.buildings
+  FOR SELECT
+  USING (true);
+
+-- Only authenticated users can create buildings
+DROP POLICY IF EXISTS "Authenticated users can insert buildings" ON public.buildings;
+CREATE POLICY "Authenticated users can insert buildings"
+  ON public.buildings
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (true);
+
+-- Authenticated users can update buildings (no ownership tracking exists)
+DROP POLICY IF EXISTS "Authenticated users can update buildings" ON public.buildings;
+CREATE POLICY "Authenticated users can update buildings"
+  ON public.buildings
+  FOR UPDATE
+  TO authenticated
+  USING (true);
+
+-- No direct deletion of buildings
+DROP POLICY IF EXISTS "No direct building deletion" ON public.buildings;
+CREATE POLICY "No direct building deletion"
+  ON public.buildings
+  FOR DELETE
+  USING (false);
+
+-- ===========================================================================
+-- 3. REVIEWS TABLE — Add missing DELETE policy
+-- ===========================================================================
+
+-- Users can delete only their own reviews
+DROP POLICY IF EXISTS "Users can delete their own reviews" ON public.reviews;
+CREATE POLICY "Users can delete their own reviews"
+  ON public.reviews
+  FOR DELETE
+  TO authenticated
+  USING (auth.uid() = user_id);

--- a/supabase/migrations/20250535_add_missing_database_indexes.sql
+++ b/supabase/migrations/20250535_add_missing_database_indexes.sql
@@ -1,0 +1,75 @@
+-- Migration: Add missing database indexes for query performance
+-- Date: 2026-03-19
+-- Issue: N-IDX (Composite: 48) — Critical tables lack indexes on columns
+--        used in WHERE, ORDER BY, and JOIN clauses
+--
+-- Evidence: Every index below is tied to a real query in the application.
+-- Using CREATE INDEX CONCURRENTLY is not available inside transactions,
+-- so we use IF NOT EXISTS for idempotency.
+
+-- ===========================================================================
+-- 1. REVIEWS TABLE — 0 existing indexes, heavily queried
+-- ===========================================================================
+
+-- Used by: supabase.ts:getByToiletId() → .eq("toilet_id", ...).order("created_at", desc)
+-- Used by: update_toilet_average_rating() trigger → WHERE toilet_id = ...
+-- Composite covers both: toilet_id equality + created_at ordering
+CREATE INDEX IF NOT EXISTS idx_reviews_toilet_id_created_at
+  ON public.reviews (toilet_id, created_at DESC);
+
+-- Used by: supabase.ts:getCurrentUserReview() → .eq("toilet_id", ...).eq("user_id", ...)
+-- Used by: create_review() RPC → SELECT ... WHERE toilet_id = ... AND user_id = ...
+-- UNIQUE enforces one review per user per toilet at the database level
+CREATE UNIQUE INDEX IF NOT EXISTS idx_reviews_toilet_id_user_id
+  ON public.reviews (toilet_id, user_id);
+
+-- Used by: update_user_review_count() trigger → WHERE id = OLD.user_id / NEW.user_id
+-- Used by: RLS policy "Users can insert their own reviews" → auth.uid() = user_id
+-- Used by: RLS policy "Users can update only their own reviews" → auth.uid() = user_id
+-- Used by: RLS policy "Users can delete their own reviews" → auth.uid() = user_id
+CREATE INDEX IF NOT EXISTS idx_reviews_user_id
+  ON public.reviews (user_id);
+
+-- ===========================================================================
+-- 2. TOILET_SUBMISSIONS TABLE — 0 existing indexes
+-- ===========================================================================
+
+-- Used by: contributionService.ts:getSubmissions() →
+--   .eq("submitter_id", uid).order("created_at", { ascending: false })
+-- Composite covers submitter filtering + chronological ordering
+CREATE INDEX IF NOT EXISTS idx_toilet_submissions_submitter_id_created_at
+  ON public.toilet_submissions (submitter_id, created_at DESC);
+
+-- Used by: process_approved_submission() trigger → WHERE status changed
+-- Used by: admin workflows filtering by submission status
+CREATE INDEX IF NOT EXISTS idx_toilet_submissions_status
+  ON public.toilet_submissions (status);
+
+-- ===========================================================================
+-- 3. TOILETS TABLE — only has GIST location index
+-- ===========================================================================
+
+-- Used by: find_toilets_within_radius() → LEFT JOIN buildings b ON t.building_id = b.id
+-- FK columns should always have indexes for JOIN performance
+CREATE INDEX IF NOT EXISTS idx_toilets_building_id
+  ON public.toilets (building_id);
+
+-- ===========================================================================
+-- 4. USER_ACTIVITY TABLE — missing entity_id index
+-- ===========================================================================
+
+-- Used by: activityService.ts:getEntityActivity() →
+--   .eq("entity_id", entityId).order("created_at", { ascending: false })
+CREATE INDEX IF NOT EXISTS idx_user_activity_entity_id
+  ON public.user_activity (entity_id);
+
+-- ===========================================================================
+-- 5. USER_NOTIFICATIONS TABLE — improve composite for common query
+-- ===========================================================================
+
+-- Used by: activityService.ts:markAllNotificationsRead() →
+--   .eq("user_id", userId).eq("is_read", false)
+-- Used by: get_user_notifications() RPC → WHERE user_id = ... AND (NOT is_read)
+-- Composite replaces scanning two separate single-column indexes
+CREATE INDEX IF NOT EXISTS idx_user_notifications_user_id_is_read
+  ON public.user_notifications (user_id, is_read);


### PR DESCRIPTION
## Summary
This PR implements functional profile tabs that fetch and display user reviews and contributions. Previously, the profile screen had placeholder tabs with no data. Now users can see their review history and submission status on the profile screen, with pull-to-refresh support.

## Key Changes

### Profile Screen Implementation
- **Reviews Tab**: Fetches user reviews from Supabase and displays them in cards showing toilet name, star rating, comment, and date
- **Contributions Tab**: Fetches user submissions via `contributionService.getMySubmissions()` and displays them with submission type and approval status badges
- **Pull-to-Refresh**: Added refresh handlers for both tabs to allow users to manually refresh data
- **Lazy Loading**: Data is only fetched when the corresponding tab is first accessed
- **Styling**: Added comprehensive card styling with status-based badge colors (approved/pending/rejected)

### Database & Service Layer
- **Supabase Reviews Service**: Added `getByUserId()` method to fetch reviews with related toilet data
- **RLS Policies**: Enabled Row Level Security on `toilets` and `buildings` tables; added missing DELETE policy for reviews
- **Database Indexes**: Added critical indexes on `reviews` (toilet_id, user_id), `toilet_submissions` (submitter_id), and other frequently-queried columns for performance

### Code Quality & Testing
- **Contribution Service**: Added `MAX_RECENT_SUBMISSIONS` constant and hard cap logic to prevent unbounded memory growth in the recent submissions cache
- **Test Coverage**: Added comprehensive edge case tests for timestamp normalization and submission cache eviction
- **Babel Config**: Fixed test environment by conditionally skipping `react-native-dotenv` plugin during Jest runs
- **Code Formatting**: Applied consistent formatting across test files and service implementations

## Implementation Details
- Reviews and contributions are fetched independently based on active tab to minimize initial load
- Status badges use semantic colors from the design system (success/warning/error)
- Timestamps are normalized to handle Supabase's Unix seconds format consistently
- Recent submissions cache now enforces a 100-entry limit with FIFO eviction to prevent memory leaks

https://claude.ai/code/session_013zcPfJVv6CmpibHt5rayxo